### PR TITLE
Change implicit generic syntax from `<a>[T] ...` to `[<a> T] ...`

### DIFF
--- a/crates/par-builtin/packages/basic/src/Sql.par
+++ b/crates/par-builtin/packages/basic/src/Sql.par
@@ -118,11 +118,11 @@ export {
   // Decode an optional value with a format. Missing columns return `.err`.
   // Designed for pipe chains:
   //   row->Sql.Field("age")->Sql.Decode(Sql.AsInt)
-  dec Decode : [Option<Value>] <a>[Format<a>] Try<Error, a>
+  dec Decode : [Option<Value>, <a> Format<a>] Try<Error, a>
 
   // Accept SQL NULL as `.none!`; otherwise parse with the provided format and
   // wrap the result in `.some`. Missing columns still error.
-  dec Nullable : <a>[Format<a>] Format<Option<a>>
+  dec Nullable : [<a> Format<a>] Format<Option<a>>
 
   // Required boolean format. A check, not a coercion, with one pragmatic
   // exception: `.int 0` and `.int 1` are accepted as booleans, because SQLite
@@ -187,12 +187,12 @@ def Field = [row, name] row.begin.case {
 // The `<a>` binder sits right before `[Format<a>]` so it is inferred from the
 // format argument (implicit generics infer only from the argument immediately
 // following the binder), while `Option<Value>` stays first for the pipe.
-def Decode = [option] <a>[format] option.case {
+def Decode = [option, <a> format] option.case {
   .some value => format.parse(value),
   .none! => .err "missing column",
 }
 
-def Nullable = <a>[format] box case {
+def Nullable = [<a> format] box case {
   .parse(value) => value.case {
     .null! => .ok .none!,
     else present => format.parse(present).case {

--- a/crates/par-builtin/packages/core/src/BoxMap.par
+++ b/crates/par-builtin/packages/core/src/BoxMap.par
@@ -40,7 +40,7 @@ export {
 
   // Builds a `BoxMap` from `(key) value` pairs.
   // If a key appears more than once, the last pair wins.
-  dec FromList : <k: data, v: box>[List<(k) v>] BoxMap<k, v>
+  dec FromList : [<k: data, v: box> List<(k) v>] BoxMap<k, v>
 }
 
 def New = external

--- a/crates/par-builtin/packages/core/src/Bytes.par
+++ b/crates/par-builtin/packages/core/src/Bytes.par
@@ -125,22 +125,22 @@ export {
 
   // Creates a byte `Parser` from a `Reader`.
   // The error type matches the reader's error type.
-  dec ParseReader : <e>[Reader<e>] Parser<e>
+  dec ParseReader : [<e> Reader<e>] Parser<e>
 
   // Consumes a parser and returns all remaining unparsed bytes.
-  dec Remainder : <e>[Parser<e>] Try<e, Bytes>
+  dec Remainder : [<e> Parser<e>] Try<e, Bytes>
 
   // Closes a parser, returning any source error.
-  dec Close : <e>[Parser<e>] Try<e, !>
+  dec Close : [<e> Parser<e>] Try<e, !>
 
   // Streams a parser's remaining input one byte at a time.
-  dec Chunks : <e>[Parser<e>] Stream<e, Bytes>
+  dec Chunks : [<e> Parser<e>] Stream<e, Bytes>
 
   // Splits a parser's remaining input on a byte separator.
-  dec SplitBy : <e>[Parser<e>] [Bytes] Stream<e, Bytes>
+  dec SplitBy : [<e> Parser<e>, Bytes] Stream<e, Bytes>
 
   // Splits a parser's remaining input on a byte pattern.
-  dec SplitByPattern : <e>[Parser<e>] [Pattern] Stream<e, Bytes>
+  dec SplitByPattern : [<e> Parser<e>, Pattern] Stream<e, Bytes>
 
   // Trims the given pattern once from the start of a byte sequence.
   dec TrimLeft : [Bytes, Pattern] Bytes
@@ -193,10 +193,10 @@ export {
   //   } in .ok!
   // )
   // ```
-  dec PipeReader : <e>[[Writer<!>] Try<e, !>] Reader<e>
+  dec PipeReader : [<e> [Writer<!>] Try<e, !>] Reader<e>
 
   // Reads all bytes from a `Reader` into a single `Bytes` value.
-  dec ReadAll : <e>[Reader<e>] Try<e, Bytes>
+  dec ReadAll : [<e> Reader<e>] Try<e, Bytes>
 }
 
 def Length = external
@@ -211,17 +211,17 @@ def EmptyReader = external
 
 def ParseReader = external
 
-def Remainder = <e>[parser] parser.case {
+def Remainder = [<e> parser] parser.case {
   .empty! => .ok "",
   .ready parser => parser.remainder,
 }
 
-def Close = <e>[parser] parser.case {
+def Close = [<e> parser] parser.case {
   .empty! => .ok!,
   .ready parser => parser.close,
 }
 
-def Chunks = <e>[parser] parser.begin.case {
+def Chunks = [<e> parser] parser.begin.case {
   .empty! => .end.ok!,
   .ready parser => parser.byte.case {
     .err e => .end.err e,
@@ -235,9 +235,9 @@ def Chunks = <e>[parser] parser.begin.case {
   },
 }
 
-def SplitBy = <e>[parser] [separator] parser->SplitByPattern(.bytes separator)
+def SplitBy = [<e> parser, separator] parser->SplitByPattern(.bytes separator)
 
-def SplitByPattern = <e>[parser] [separator] parser.begin.case {
+def SplitByPattern = [<e> parser, separator] parser.begin.case {
   .empty! => .end.ok!,
   .ready parser => parser.minMax(.repeat.one.any!, separator).case {
     .err e => .end.err e,
@@ -342,7 +342,7 @@ def ReplacePattern = [bytes, pattern, replace]
 
 def PipeReader = external
 
-def ReadAll = <e>[reader] ParseReader(reader)->Remainder
+def ReadAll = [<e> reader] ParseReader(reader)->Remainder
 
 // Helpers
 

--- a/crates/par-builtin/packages/core/src/Cell.par
+++ b/crates/par-builtin/packages/core/src/Cell.par
@@ -17,10 +17,10 @@ export {
 
   // Serves a value through a `Cell`.
   // Returns the final value when all clients are done.
-  dec Share : <a>[a] [dual Cell<a>] a
+  dec Share : [<a> a, dual Cell<a>] a
 }
 
-def Share = <a>[value] [client] poll(client) {
+def Share = [<a> value, client] poll(client) {
   session => session.case {
     .end! => submit(),
     .split(client1) client2 => submit(client1, client2),

--- a/crates/par-builtin/packages/core/src/Data.par
+++ b/crates/par-builtin/packages/core/src/Data.par
@@ -6,9 +6,9 @@ import {
 }
 
 export {
-  dec ToString : <a: data>[a] String
+  dec ToString : [<a: data> a] String
 
-  dec Compare : <a: data>[(a) a] Ordering
+  dec Compare : [<a: data> (a) a] Ordering
 }
 
 def ToString = external

--- a/crates/par-builtin/packages/core/src/Json.par
+++ b/crates/par-builtin/packages/core/src/Json.par
@@ -64,13 +64,13 @@ export {
   //
   // Use `Json.Map` when parsing cannot fail once the underlying format
   // succeeds. Use `Json.Then` for fallible post-processing.
-  dec Map : <a>[Format<a>] <b>[box [a] b] Format<b>
+  dec Map : [<a> Format<a>, <b> box [a] b] Format<b>
 
   // Applies a fallible post-processing step to a successful parse result.
   //
   // The mapping function returns `.ok value` to accept the parsed result or
   // `.err!` to reject it.
-  dec Then : <a>[Format<a>] <b>[box [a] Try<!, b>] Format<b>
+  dec Then : [<a> Format<a>, <b> box [a] Try<!, b>] Format<b>
 
   // Matches exactly one JSON value.
   dec Literal : [Json] Format<!>
@@ -91,10 +91,10 @@ export {
   //
   // The item type must be non-linear because earlier parsed items may need to
   // be discarded if a later item fails to parse.
-  dec List : <a: box>[Format<a>] Format<CoreList<a>>
+  dec List : [<a: box> Format<a>] Format<CoreList<a>>
 
   // Parses a JSON object with the given object format.
-  dec Object : <a>[ObjectFormat<a>] Format<a>
+  dec Object : [<a> ObjectFormat<a>] Format<a>
 
   // Parses an empty object. Ignores any fields, does not fail if fields are present.
   dec Empty : ObjectFormat<!>
@@ -103,12 +103,12 @@ export {
   //
   // For example, `Json.Field("name", Json.String)` accepts an object whose
   // `"name"` field is a JSON string.
-  dec Field : [CoreString] <a>[Format<a>] ObjectFormat<a>
+  dec Field : [CoreString, <a> Format<a>] ObjectFormat<a>
 
   // Parses an optional object field with the given format.
   //
   // Missing fields produce `.ok .none!`. Present fields must parse successfully.
-  dec OptionalField : [CoreString] <a>[Format<a>] ObjectFormat<Option<a>>
+  dec OptionalField : [CoreString, <a> Format<a>] ObjectFormat<Option<a>>
 
   // Runs two object formats against the same object and returns both results.
   //
@@ -118,7 +118,7 @@ export {
   //
   // Both object formats return non-linear values because either side may need to be
   // discarded if the other side fails.
-  dec And : <a: box>[ObjectFormat<a>] <b: box>[ObjectFormat<b>] ObjectFormat<(b) a>
+  dec And : [<a: box> ObjectFormat<a>, <b: box> ObjectFormat<b>] ObjectFormat<(b) a>
 
   // Tries multiple formats in order and returns the first successful result.
   //
@@ -136,7 +136,7 @@ export {
   //   (Json.String) box [text] .text text,
   // ))
   // ```
-  dec Union : <a>[CoreList<<b>(Format<b>) box [b] a>] Format<a>
+  dec Union : [<a> CoreList<(<b> Format<b>) box [b] a>] Format<a>
 
   // Parses tagged JSON objects by matching one field against literal JSON tags.
   //
@@ -156,11 +156,11 @@ export {
   //   (.string "say", Json.Field("message", Json.String)) box [message] .say message,
   // ))
   // ```
-  dec Tagged : [CoreString] <a>[CoreList<(Json) <b>(ObjectFormat<b>) box [b] a>] Format<a>
+  dec Tagged : [CoreString, <a> CoreList<(Json, <b> ObjectFormat<b>) box [b] a>] Format<a>
 
   // Accepts JSON `null` as `.ok .none!`, otherwise parses with the given format
   // and wraps the result in `.some`.
-  dec OrNull : <a>[Format<a>] Format<Option<a>>
+  dec OrNull : [<a> Format<a>] Format<Option<a>>
 }
 
 def Encode = external
@@ -178,20 +178,20 @@ def Equals = [json1, json2] json1.begin.case {
   })
 }
 
-dec ListEquals : <a>[CoreList<box a>] <b>[CoreList<box b>] [box [a, b] CoreBool] CoreBool
-def ListEquals = <a>[list1] <b>[list2] [eq] list1.begin.case {
+dec ListEquals : [<a> CoreList<box a>, <b> CoreList<box b>, box [a, b] CoreBool] CoreBool
+def ListEquals = [<a> list1, <b> list2, eq] list1.begin.case {
   .end! => list2 is .end!,
   .item(x) list1 => list2 is .item(y) list2 and eq(x, y) and list1.loop
 }
 
-def Map = <a>[format] <b>[f] box case {
+def Map = [<a> format, <b> f] box case {
   .parse(json) => format.parse(json).case {
     .ok value => .ok f(value),
     .err! => .err!,
   }
 }
 
-def Then = <a>[format] <b>[f] box case {
+def Then = [<a> format, <b> f] box case {
   .parse(json) => format.parse(json).case {
     .ok value => f(value),
     .err! => .err!,
@@ -233,7 +233,7 @@ def Number = box case {
   }
 }
 
-def List = <a: box>[item] box case {
+def List = [<a: box> item] box case {
   .parse(json) => json.case {
     .list xs => xs.begin.case {
       .end! => .ok .end!,
@@ -247,7 +247,7 @@ def List = <a: box>[item] box case {
   }
 }
 
-def Object = <a>[format] box case {
+def Object = [<a> format] box case {
   .parse(json) => json.case {
     .object o => format.parseObject(o),
     else _ => .err!,
@@ -258,7 +258,7 @@ def Empty = box case {
   .parseObject(_) => .ok!,
 }
 
-def Field = [key] <a>[format] box case {
+def Field = [key, <a> format] box case {
   .parseObject(object) => if {
     not object.get(key) is .some json => .err!,
     not format.parse(json) is .ok value => .err!,
@@ -266,7 +266,7 @@ def Field = [key] <a>[format] box case {
   }
 }
 
-def OptionalField = [key] <a>[format] box case {
+def OptionalField = [key, <a> format] box case {
   .parseObject(object) => object.get(key).case {
     .some json => format.parse(json).case {
       .ok value => .ok .some value,
@@ -276,7 +276,7 @@ def OptionalField = [key] <a>[format] box case {
   }
 }
 
-def And = <a: box>[format1] <b: box>[format2] box case {
+def And = [<a: box> format1, <b: box> format2] box case {
   .parseObject(object) => if {
     not format2.parseObject(object) is .ok y => .err!,
     not format1.parseObject(object) is .ok x => .err!,
@@ -284,9 +284,9 @@ def And = <a: box>[format1] <b: box>[format2] box case {
   }
 }
 
-def Union = <a>[variants] box case {
+def Union = [<a> variants] box case {
   .parse(json) => variants.begin.case {
-    .item(<b>(format) map) rest => format.parse(json).case {
+    .item((<b> format) map) rest => format.parse(json).case {
       .ok value => .ok map(value),
       .err! => rest.loop,
     }
@@ -294,10 +294,10 @@ def Union = <a>[variants] box case {
   }
 }
 
-def Tagged = [tagKey] <a>[variants] box case {
+def Tagged = [tagKey, <a> variants] box case {
   .parse(json) => if {
     json is .object o and o.get(tagKey) is .some actualTag => variants.begin.case {
-      .item((tag) <b>(format) map) rest => if {
+      .item((tag, <b> format) map) rest => if {
         tag->Equals(actualTag) => format.parseObject(o).case {
           .ok value => .ok map(value),
           .err! => .err!,
@@ -310,7 +310,7 @@ def Tagged = [tagKey] <a>[variants] box case {
   }
 }
 
-def OrNull = <a>[format] box case {
+def OrNull = [<a> format] box case {
   .parse(json) => json.case {
     .null! => .ok .none!,
     else json => format.parse(json).case {

--- a/crates/par-builtin/packages/core/src/List.par
+++ b/crates/par-builtin/packages/core/src/List.par
@@ -39,19 +39,19 @@ export {
   // *(1, 2, 3)->List.Map(box [n] n * 2)
   // // = *(2, 4, 6)
   // ```
-  dec Map : <a>[List<a>] <b>[box [a] b] List<b>
+  dec Map : [<a> List<a>, <b> box [a] b] List<b>
 
   // Maps each element to a list, then concatenates the result.
-  dec FlatMap : <a>[List<a>] <b>[box [a] List<b>] List<b>
+  dec FlatMap : [<a> List<a>, <b> box [a] List<b>] List<b>
 
   // Maps each element to an optional value, keeping only the present results.
-  dec FilterMap : <a>[List<a>] <b>[box [a] Option<b>] List<b>
+  dec FilterMap : [<a> List<a>, <b> box [a] Option<b>] List<b>
 
   // Keeps the elements for which the test function returns `.true!`.
-  dec Filter : <a: box>[List<a>] [box [a] Bool] List<a>
+  dec Filter : [<a: box> List<a>, box [a] Bool] List<a>
 
   // Returns the first element for which the test function returns `.true!`.
-  dec Find : <a: box>[List<a>] [box [a] Bool] Option<a>
+  dec Find : [<a: box> List<a>, box [a] Bool] Option<a>
 
   // Applies a folding function repeatedly to the current result and each list
   // element, returning the final result.
@@ -72,75 +72,75 @@ export {
   // )
   // console.close
   // ```
-  dec ForEach : <r>[r] <a>[List<a>] [box [r, a] r] r
+  dec ForEach : [<r> r, <a> List<a>, box [r, a] r] r
 
   // Returns the number of elements in a list.
-  dec Length : <a: box>[List<a>] Nat
+  dec Length : [<a: box> List<a>] Nat
 
   // Flattens a list of lists into a single list.
-  dec Concat : <a>[List<List<a>>] List<a>
+  dec Concat : [<a> List<List<a>>] List<a>
 
   // Returns a list with the elements in reverse order.
-  dec Reverse : <a>[List<a>] List<a>
+  dec Reverse : [<a> List<a>] List<a>
 
   // Yields all items from a source list onto a destination channel, consuming the source.
-  dec Copy : <a>[dual List<a>] [List<a>] dual List<a>
+  dec Copy : [<a> dual List<a>, List<a>] dual List<a>
 
   // Pairs each element with its zero-based index.
-  dec Enumerate : <a>[List<a>] List<(Nat) a>
+  dec Enumerate : [<a> List<a>] List<(Nat) a>
 
   // Zips two lists into a list of pairs. Stops at the shorter list.
-  dec Zip : <a: box>[List<a>] <b: box>[List<b>] List<(a) b>
+  dec Zip : [<a: box> List<a>, <b: box> List<b>] List<(a) b>
 
   // Splits a list of pairs into a pair of lists.
-  dec Unzip : <a, b>[List<(a) b>] (List<a>) List<b>
+  dec Unzip : [<a, b> List<(a) b>] (List<a>) List<b>
 
   // Returns `.true!` if the test function holds for all elements.
   // Short-circuits on the first `.false!`.
-  dec All : <a: box>[List<a>] [box [a] Bool] Bool
+  dec All : [<a: box> List<a>, box [a] Bool] Bool
 
   // Returns `.true!` if the test function holds for at least one element.
   // Short-circuits on the first `.true!`.
-  dec Any : <a: box>[List<a>] [box [a] Bool] Bool
+  dec Any : [<a: box> List<a>, box [a] Bool] Bool
 
   // Returns up to the requested number of elements from the start of a list.
-  dec Take : <a: box>[List<a>] [Nat] List<a>
+  dec Take : [<a: box> List<a>, Nat] List<a>
 
   // Drops the requested number of elements from the start of a list.
-  dec Drop : <a: box>[List<a>] [Nat] List<a>
+  dec Drop : [<a: box> List<a>, Nat] List<a>
 
   // Takes elements from the start while the test function returns `.true!`.
-  dec TakeWhile : <a: box>[List<a>] [box [a] Bool] List<a>
+  dec TakeWhile : [<a: box> List<a>, box [a] Bool] List<a>
 
   // Drops elements from the start while the test function returns `.true!`.
-  dec DropWhile : <a: box>[List<a>] [box [a] Bool] List<a>
+  dec DropWhile : [<a: box> List<a>, box [a] Bool] List<a>
 
   // Returns the smallest element, or `.none!` for an empty list.
-  dec Min : <a: data>[List<a>] Option<a>
+  dec Min : [<a: data> List<a>] Option<a>
 
   // Returns the largest element, or `.none!` for an empty list.
-  dec Max : <a: data>[List<a>] Option<a>
+  dec Max : [<a: data> List<a>] Option<a>
 
   // Sorts a list in ascending data order. Equal keys keep their original order.
-  dec Sort : <a: data>[List<a>] List<a>
+  dec Sort : [<a: data> List<a>] List<a>
 
   // Sorts a list in descending data order. Equal keys keep their original order.
-  dec SortDesc : <a: data>[List<a>] List<a>
+  dec SortDesc : [<a: data> List<a>] List<a>
 
   // Sorts a non-linear list by an extracted data key.
-  dec SortBy : <a: box>[List<a>] <k: data>[box [a] k] List<a>
+  dec SortBy : [<a: box> List<a>, <k: data> box [a] k] List<a>
 
   // Sorts a non-linear list by an extracted data key in descending order.
-  dec SortDescBy : <a: box>[List<a>] <k: data>[box [a] k] List<a>
+  dec SortDescBy : [<a: box> List<a>, <k: data> box [a] k] List<a>
 
   // Sorts a linear list by a function that returns both the key and the item.
-  dec SortLinearBy : <a>[List<a>] <k: data>[box [a] (k) a] List<a>
+  dec SortLinearBy : [<a> List<a>, <k: data> box [a] (k) a] List<a>
 
   // Sorts a linear list by a key in descending order.
-  dec SortLinearDescBy : <a>[List<a>] <k: data>[box [a] (k) a] List<a>
+  dec SortLinearDescBy : [<a> List<a>, <k: data> box [a] (k) a] List<a>
 
   // Calculates the sum of all elements in a list.
-  dec Sum : <a: number>[List<a>] a
+  dec Sum : [<a: number> List<a>] a
 }
 
 def Builder = [type a]
@@ -150,12 +150,12 @@ def Builder = [type a]
     .build => append(.end!),
   }
 
-def Map = <a>[list] <b>[f] list.begin.case {
+def Map = [<a> list, <b> f] list.begin.case {
   .end! => .end!
   .item(v) list => .item(f(v)) list.loop,
 }
 
-def FlatMap = <a>[list] <b>[f] list.begin.case {
+def FlatMap = [<a> list, <b> f] list.begin.case {
   .end! => .end!,
   .item(v) list => f(v).begin@flat.case {
     .end! => list.loop,
@@ -163,7 +163,7 @@ def FlatMap = <a>[list] <b>[f] list.begin.case {
   },
 }
 
-def FilterMap = <a>[list] <b>[f] list.begin.case {
+def FilterMap = [<a> list, <b> f] list.begin.case {
   .end! => .end!,
   .item(v) list => f(v).case {
     .some v => .item(v) list.loop,
@@ -171,7 +171,7 @@ def FilterMap = <a>[list] <b>[f] list.begin.case {
   },
 }
 
-def Filter = <a: box>[list] [f] list.begin.case {
+def Filter = [<a: box> list, f] list.begin.case {
   .end! => .end!,
   .item(v) list => f(v).case {
     .true! => .item(v) list.loop,
@@ -179,7 +179,7 @@ def Filter = <a: box>[list] [f] list.begin.case {
   },
 }
 
-def Find = <a: box>[list] [f] list.begin.case {
+def Find = [<a: box> list, f] list.begin.case {
   .end! => .none!,
   .item(v) list => f(v).case {
     .true! => .some v,
@@ -187,19 +187,19 @@ def Find = <a: box>[list] [f] list.begin.case {
   },
 }
 
-def ForEach = <r>[result] <a>[list] [f] list.begin.case {
+def ForEach = [<r> result, <a> list, f] list.begin.case {
   .end! => result,
   .item(v) list => do { result->f(v) } in list.loop,
 }
 
-def Length = <a: box>[list]
+def Length = [<a: box> list]
   let len = 0 in
   list.begin.case {
     .end! => len,
     .item(_) list => do { len += 1 } in list.loop,
   }
 
-def Concat = <a>[lists] chan yield {
+def Concat = [<a> lists] chan yield {
   lists.begin.case {
     .item(list) => {
       yield->Copy(list)
@@ -211,7 +211,7 @@ def Concat = <a>[lists] chan yield {
   }
 }
 
-def Reverse = <a>[list]
+def Reverse = [<a> list]
   let reversed: List<a> = .end! in
   list.begin.case {
     .end! => reversed,
@@ -220,7 +220,7 @@ def Reverse = <a>[list]
     } in list.loop,
   }
 
-def Copy = <a>[dst] [src] do {
+def Copy = [<a> dst, src] do {
   src.begin.case {
     .end! => {},
     .item(v) src => {
@@ -230,7 +230,7 @@ def Copy = <a>[dst] [src] do {
   }
 } in dst
 
-def Enumerate = <a>[list]
+def Enumerate = [<a> list]
   let index = 0 in
   list.begin.case {
     .end! => .end!,
@@ -240,7 +240,7 @@ def Enumerate = <a>[list]
     } in .item((current) v) list.loop,
   }
 
-def Zip = <a: box>[list1] <b: box>[list2] chan yield {
+def Zip = [<a: box> list1, <b: box> list2] chan yield {
   list1.begin.case {
     .end! => { yield.end! },
     .item(v1) list1 => {
@@ -255,14 +255,14 @@ def Zip = <a: box>[list1] <b: box>[list2] chan yield {
   }
 }
 
-def Unzip = <a, b>[list] list.begin.case {
+def Unzip = [<a, b> list] list.begin.case {
   .end! => (.end!) .end!,
   .item((x) y) xys => do {
     let (xs) ys = xys.loop
   } in (.item(x) xs) .item(y) ys
 }
 
-def All = <a: box>[list] [f]
+def All = [<a: box> list, f]
   list.begin.case {
     .end! => .true!,
     .item(v) list => f(v).case {
@@ -271,9 +271,9 @@ def All = <a: box>[list] [f]
     },
   }
 
-def Any = <a: box>[list] [f] {not list->All(box [v] {not f(v)})}
+def Any = [<a: box> list, f] {not list->All(box [v] {not f(v)})}
 
-def Take = <a: box>[list] [n]
+def Take = [<a: box> list, n]
   Nat.Repeat(n).begin.case {
     .end! => .end!,
     .step next => list.case {
@@ -282,7 +282,7 @@ def Take = <a: box>[list] [n]
     }
   }
 
-def Drop = <a: box>[list] [n]
+def Drop = [<a: box> list, n]
   Nat.Repeat(n).begin.case {
     .end! => list,
     .step next => list.case {
@@ -291,7 +291,7 @@ def Drop = <a: box>[list] [n]
     },
   }
 
-def TakeWhile = <a: box>[list] [f] list.begin.case {
+def TakeWhile = [<a: box> list, f] list.begin.case {
   .end! => .end!,
   .item(v) list => f(v).case {
     .true! => .item(v) list.loop,
@@ -299,7 +299,7 @@ def TakeWhile = <a: box>[list] [f] list.begin.case {
   },
 }
 
-def DropWhile = <a: box>[list] [f] list.begin.case {
+def DropWhile = [<a: box> list, f] list.begin.case {
   .end! => .end!,
   .item(v) list => f(v).case {
     .true! => list.loop,
@@ -307,7 +307,7 @@ def DropWhile = <a: box>[list] [f] list.begin.case {
   },
 }
 
-def Min = <a: data>[list] list.case {
+def Min = [<a: data> list] list.case {
   .end! => .none!,
   .item(best) list => .some {
     list.begin.case {
@@ -319,7 +319,7 @@ def Min = <a: data>[list] list.case {
   },
 }
 
-def Max = <a: data>[list] list.case {
+def Max = [<a: data> list] list.case {
   .end! => .none!,
   .item(best) list => .some {
     list.begin.case {
@@ -343,7 +343,7 @@ def SortLinearBy = external
 
 def SortLinearDescBy = external
 
-def Sum = <a: number>[list] do {
+def Sum = [<a: number> list] do {
   let sum = Number.Zero(type a)
 } in list.begin.case {
   .end! => sum,

--- a/crates/par-builtin/packages/core/src/Map.par
+++ b/crates/par-builtin/packages/core/src/Map.par
@@ -33,7 +33,7 @@ export {
 
   // Builds a `Map` from `(key) value` pairs.
   // If a key appears more than once, the last pair wins.
-  dec FromList : [type v] <k: data>[List<(k) box v>] Map<k, v>
+  dec FromList : [type v, <k: data> List<(k) box v>] Map<k, v>
 }
 
 def New = external

--- a/crates/par-builtin/packages/core/src/Number.par
+++ b/crates/par-builtin/packages/core/src/Number.par
@@ -3,15 +3,15 @@ export module Number
 export {
   dec Zero : [type a: number] a
 
-  dec Add : <a: number>[(a) a] a
+  dec Add : [<a: number> (a) a] a
 
-  dec Sub : <a: signed>[(a) a] a
+  dec Sub : [<a: signed> (a) a] a
 
-  dec Mul : <a: number>[(a) a] a
+  dec Mul : [<a: number> (a) a] a
 
-  dec Div : <a: number>[(a) a] a
+  dec Div : [<a: number> (a) a] a
 
-  dec Neg : <a: signed>[a] a
+  dec Neg : [<a: signed> a] a
 }
 
 dec Zero_ : [type a: number, !] a

--- a/crates/par-builtin/packages/core/src/Option.par
+++ b/crates/par-builtin/packages/core/src/Option.par
@@ -18,42 +18,42 @@ export {
   }
 
   // Transforms the contained value, if present.
-  dec Map : <a>[Option<a>] <b>[box [a] b] Option<b>
+  dec Map : [<a> Option<a>, <b> box [a] b] Option<b>
 
   // Transforms the contained value with a computation that may return no value.
-  dec FlatMap : <a>[Option<a>] <b>[box [a] Option<b>] Option<b>
+  dec FlatMap : [<a> Option<a>, <b> box [a] Option<b>] Option<b>
 
   // Keeps the contained value only if it satisfies the predicate.
-  dec Filter : <a: box>[Option<a>] [box [a] Bool] Option<a>
+  dec Filter : [<a: box> Option<a>, box [a] Bool] Option<a>
 
   // Converts `.some value` to a singleton list and `.none!` to an empty list.
-  dec ToList : <a>[Option<a>] List<a>
+  dec ToList : [<a> Option<a>] List<a>
 
   // Converts `.some value` to `.ok value` and `.none!` to the provided error.
-  dec ToResult : <a>[Option<a>] <e: box>[e] Try<e, a>
+  dec ToResult : [<a> Option<a>, <e: box> e] Try<e, a>
 }
 
-def Map = <a>[option] <b>[f] option.case {
+def Map = [<a> option, <b> f] option.case {
   .some a => .some f(a),
   .none! => .none!,
 }
 
-def FlatMap = <a>[option] <b>[f] option.case {
+def FlatMap = [<a> option, <b> f] option.case {
   .some a => f(a),
   .none! => .none!,
 }
 
-def Filter = <a: box>[option] [p] if {
+def Filter = [<a: box> option, p] if {
   option is .some value and p(value) => .some value,
   else => .none!,
 }
 
-def ToList = <a>[option] option.case {
+def ToList = [<a> option] option.case {
   .some a => .item(a) .end!,
   .none! => .end!,
 }
 
-def ToResult = <a>[option] <e: box>[e] option.case {
+def ToResult = [<a> option, <e: box> e] option.case {
   .some a => .ok a,
   .none! => .err e,
 }

--- a/crates/par-builtin/packages/core/src/Stream.par
+++ b/crates/par-builtin/packages/core/src/Stream.par
@@ -31,66 +31,66 @@ export {
   }
 
   // Collects the stream into a list, preserving any stream error.
-  dec ToList : <e, a: box>[Stream<e, a>] Try<e, List<a>>
+  dec ToList : [<e, a: box> Stream<e, a>] Try<e, List<a>>
 
   // Creates an infallible stream from a list.
-  dec FromList : <a: box>[List<a>] Stream<either {}, a>
+  dec FromList : [<a: box> List<a>] Stream<either {}, a>
 
   // Applies a mapping function to each item of a stream.
-  dec Map : <e, a>[Stream<e, a>] <b>[box [a] b] Stream<e, b>
+  dec Map : [<e, a> Stream<e, a>, <b> box [a] b] Stream<e, b>
 
   // Pairs each item with its zero-based index.
-  dec Enumerate : <e, a>[Stream<e, a>] Stream<e, (Nat) a>
+  dec Enumerate : [<e, a> Stream<e, a>] Stream<e, (Nat) a>
 
   // Applies a mapping function to the stream's error type.
-  dec MapErr : <e1, a>[Stream<e1, a>] <e2>[box [e1] e2] Stream<e2, a>
+  dec MapErr : [<e1, a> Stream<e1, a>, <e2> box [e1] e2] Stream<e2, a>
 
   // Maps each item to a stream, then flattens the result.
-  dec FlatMap : <e: box, a>[Stream<e, a>] <b>[box [a] Stream<e, b>] Stream<e, b>
+  dec FlatMap : [<e: box, a> Stream<e, a>, <b> box [a] Stream<e, b>] Stream<e, b>
 
   // Flattens a stream of streams into a single stream.
-  dec Flatten : <e: box, a>[Stream<e, Stream<e, a>>] Stream<e, a>
+  dec Flatten : [<e: box, a> Stream<e, Stream<e, a>>] Stream<e, a>
 
   // Concatenates a list of streams into a single stream.
-  dec Concat : <e: box, a>[List<Stream<e, a>>] Stream<e, a>
+  dec Concat : [<e: box, a> List<Stream<e, a>>] Stream<e, a>
 
   // Keeps the items for which the test function returns `.true!`.
-  dec Filter : <e, a: box>[Stream<e, a>] [box [a] Bool] Stream<e, a>
+  dec Filter : [<e, a: box> Stream<e, a>, box [a] Bool] Stream<e, a>
 
   // Yields at most the requested number of items, cancelling the source if
   // enough items were taken before it ended.
-  dec Take : <e, a: box>[Stream<e, a>] [Nat] Stream<e, a>
+  dec Take : [<e, a: box> Stream<e, a>, Nat] Stream<e, a>
 
   // Skips the requested number of items and yields the rest.
-  dec Drop : <e, a: box>[Stream<e, a>] [Nat] Stream<e, a>
+  dec Drop : [<e, a: box> Stream<e, a>, Nat] Stream<e, a>
 
   // Yields items while the test function returns `.true!`, then cancels the source.
-  dec TakeWhile : <e, a: box>[Stream<e, a>] [box [a] Bool] Stream<e, a>
+  dec TakeWhile : [<e, a: box> Stream<e, a>, box [a] Bool] Stream<e, a>
 
   // Skips items while the test function returns `.true!`, then yields the rest.
-  dec DropWhile : <e, a: box>[Stream<e, a>] [box [a] Bool] Stream<e, a>
+  dec DropWhile : [<e, a: box> Stream<e, a>, box [a] Bool] Stream<e, a>
 
   // Folds over the stream. The returned pair contains the stream completion
   // status and the final accumulator.
-  dec ForEach : <r>[r] <e, a>[Stream<e, a>] [box [r, a] r] (Try<e, !>) r
+  dec ForEach : [<r> r, <e, a> Stream<e, a>, box [r, a] r] (Try<e, !>) r
 
   // Returns `.ok.true!` if the test function holds for every item.
   // Short-circuits and cancels the source on the first `.false!`.
-  dec All : <e, a>[Stream<e, a>] [box [a] Bool] Try<e, Bool>
+  dec All : [<e, a> Stream<e, a>, box [a] Bool] Try<e, Bool>
 
   // Returns `.ok.true!` if the test function holds for at least one item.
   // Short-circuits and cancels the source on the first `.true!`.
-  dec Any : <e, a>[Stream<e, a>] [box [a] Bool] Try<e, Bool>
+  dec Any : [<e, a> Stream<e, a>, box [a] Bool] Try<e, Bool>
 
   // Calculates the sum of all stream items.
-  dec Sum : <e, a: number>[Stream<e, a>] Try<e, a>
+  dec Sum : [<e, a: number> Stream<e, a>] Try<e, a>
 
   // Cancels a stream if it has not already ended, returning any cancellation
   // or completion error.
-  dec Cancel : <e, a>[Stream<e, a>] Try<e, !>
+  dec Cancel : [<e, a> Stream<e, a>] Try<e, !>
 }
 
-def ToList = <e, a: box>[stream]
+def ToList = [<e, a: box> stream]
   let builder = List.Builder(type a) in
   stream.begin.case {
     .end result => result.case {
@@ -103,7 +103,7 @@ def ToList = <e, a: box>[stream]
     } in stream.loop,
   }
 
-def FromList = <a: box>[list] list.begin.case {
+def FromList = [<a: box> list] list.begin.case {
   .end! => .end.ok!,
   .item(value) list => .item case {
     .cancel => .ok!,
@@ -111,7 +111,7 @@ def FromList = <a: box>[list] list.begin.case {
   },
 }
 
-def Map = <e, a>[stream] <b>[f] stream.begin.case {
+def Map = [<e, a> stream, <b> f] stream.begin.case {
   .end res => .end res,
   .item stream => .item case {
     .cancel => stream.cancel,
@@ -119,7 +119,7 @@ def Map = <e, a>[stream] <b>[f] stream.begin.case {
   }
 }
 
-def Enumerate = <e, a>[stream]
+def Enumerate = [<e, a> stream]
   let index = 0 in
   stream.begin.case {
     .end result => .end result,
@@ -133,7 +133,7 @@ def Enumerate = <e, a>[stream]
     },
   }
 
-def MapErr = <e1, a>[stream] <e2>[f] stream.begin.case {
+def MapErr = [<e1, a> stream, <e2> f] stream.begin.case {
   .end res => .end res->Try.MapErr(f),
   .item stream => .item case {
     .cancel => stream.cancel->Try.MapErr(f),
@@ -141,9 +141,9 @@ def MapErr = <e1, a>[stream] <e2>[f] stream.begin.case {
   },
 }
 
-def FlatMap = <e: box, a>[stream] <b>[f] stream->Map(f)->Flatten
+def FlatMap = [<e: box, a> stream, <b> f] stream->Map(f)->Flatten
 
-def Flatten = <e: box, a>[streams] streams.begin@outer.case {
+def Flatten = [<e: box, a> streams] streams.begin@outer.case {
   .end result => .end result,
   .item streams => do {
     streams.get[stream]
@@ -168,7 +168,7 @@ def Flatten = <e: box, a>[streams] streams.begin@outer.case {
   },
 }
 
-def Concat = <e: box, a>[streams] streams.begin@outer.case {
+def Concat = [<e: box, a> streams] streams.begin@outer.case {
   .end! => .end.ok!,
   .item(stream) streams => stream.begin@inner.case {
     .end result => result.case {
@@ -218,7 +218,7 @@ def Concat = <e: box, a>[streams] streams.begin@outer.case {
   },
 }
 
-def Filter = <e, a: box>[stream] [predicate] stream.begin.case {
+def Filter = [<e, a: box> stream, predicate] stream.begin.case {
   .end result => .end result,
   .item stream => do {
     stream.get[value]
@@ -231,7 +231,7 @@ def Filter = <e, a: box>[stream] [predicate] stream.begin.case {
   },
 }
 
-def Take = <e, a: box>[stream] [n]
+def Take = [<e, a: box> stream, n]
   Nat.Repeat(n).begin@take.case {
     .end! => .end stream->Cancel,
     .step steps => stream.begin.case {
@@ -243,7 +243,7 @@ def Take = <e, a: box>[stream] [n]
     },
   }
 
-def Drop = <e, a: box>[stream] [n]
+def Drop = [<e, a: box> stream, n]
   Nat.Repeat(n).begin@drop.case {
     .end! => stream,
     .step steps => stream.begin.case {
@@ -252,7 +252,7 @@ def Drop = <e, a: box>[stream] [n]
     },
   }
 
-def TakeWhile = <e, a: box>[stream] [predicate] stream.begin.case {
+def TakeWhile = [<e, a: box> stream, predicate] stream.begin.case {
   .end result => .end result,
   .item stream => do {
     stream.get[value]
@@ -265,7 +265,7 @@ def TakeWhile = <e, a: box>[stream] [predicate] stream.begin.case {
   },
 }
 
-def DropWhile = <e, a: box>[stream] [predicate] stream.begin.case {
+def DropWhile = [<e, a: box> stream, predicate] stream.begin.case {
   .end result => .end result,
   .item stream => do {
     stream.get[value]
@@ -278,7 +278,7 @@ def DropWhile = <e, a: box>[stream] [predicate] stream.begin.case {
   },
 }
 
-def ForEach = <r>[result] <e, a>[stream] [f] stream.begin.case {
+def ForEach = [<r> result, <e, a> stream, f] stream.begin.case {
   .end status => (status) result,
   .item stream => do {
     stream.get[value]
@@ -286,7 +286,7 @@ def ForEach = <r>[result] <e, a>[stream] [f] stream.begin.case {
   } in stream.loop,
 }
 
-def All = <e, a>[stream] [predicate] stream.begin.case {
+def All = [<e, a> stream, predicate] stream.begin.case {
   .end result => result.case {
     .ok! => .ok.true!,
     .err e => .err e,
@@ -302,7 +302,7 @@ def All = <e, a>[stream] [predicate] stream.begin.case {
   },
 }
 
-def Any = <e, a>[stream] [predicate] stream.begin.case {
+def Any = [<e, a> stream, predicate] stream.begin.case {
   .end result => result.case {
     .ok! => .ok.false!,
     .err e => .err e,
@@ -318,7 +318,7 @@ def Any = <e, a>[stream] [predicate] stream.begin.case {
   },
 }
 
-def Sum = <e, a: number>[stream] do {
+def Sum = [<e, a: number> stream] do {
   let sum = Number.Zero(type a)
 } in stream.begin.case {
   .end result => result.case {
@@ -331,7 +331,7 @@ def Sum = <e, a: number>[stream] do {
   } in stream.loop,
 }
 
-def Cancel = <e, a>[stream] stream.begin.case {
+def Cancel = [<e, a> stream] stream.begin.case {
   .end result => result,
   .item stream => stream.cancel,
 }

--- a/crates/par-builtin/packages/core/src/String.par
+++ b/crates/par-builtin/packages/core/src/String.par
@@ -125,22 +125,22 @@ export {
 
   // Creates a string `Parser` from a `Bytes.Reader`.
   // The error type matches the reader's error type.
-  dec ParseReader : <e>[Bytes.Reader<e>] Parser<e>
+  dec ParseReader : [<e> Bytes.Reader<e>] Parser<e>
 
   // Consumes a parser and returns all remaining unparsed input.
-  dec Remainder : <e>[Parser<e>] Try<e, String>
+  dec Remainder : [<e> Parser<e>] Try<e, String>
 
   // Closes a parser, returning any source error.
-  dec Close : <e>[Parser<e>] Try<e, !>
+  dec Close : [<e> Parser<e>] Try<e, !>
 
   // Splits a parser's remaining input into lines separated by `\n` or `\r\n`.
-  dec Lines : <e>[Parser<e>] Stream<e, String>
+  dec Lines : [<e> Parser<e>] Stream<e, String>
 
   // Splits a parser's remaining input on a string separator.
-  dec SplitBy : <e>[Parser<e>] [String] Stream<e, String>
+  dec SplitBy : [<e> Parser<e>, String] Stream<e, String>
 
   // Splits a parser's remaining input on a string pattern.
-  dec SplitByPattern : <e>[Parser<e>] [Pattern] Stream<e, String>
+  dec SplitByPattern : [<e> Parser<e>, Pattern] Stream<e, String>
 
   // Trims whitespace from both ends of a string.
   dec Trim : [String] String
@@ -201,7 +201,7 @@ export {
 
   // Reads all bytes from a `Reader` and decodes them into a `String`,
   // replacing invalid sequences with the Unicode replacement character.
-  dec ReadAll : <e>[Bytes.Reader<e>] Try<e, String>
+  dec ReadAll : [<e> Bytes.Reader<e>] Try<e, String>
 }
 
 def Quote = external
@@ -218,21 +218,21 @@ def Parse = external
 
 def ParseReader = external
 
-def Remainder = <e>[parser] parser.case {
+def Remainder = [<e> parser] parser.case {
   .empty! => .ok "",
   .ready parser => parser.remainder,
 }
 
-def Close = <e>[parser] parser.case {
+def Close = [<e> parser] parser.case {
   .empty! => .ok!,
   .ready parser => parser.close,
 }
 
-def Lines = <e>[parser] parser->SplitByPattern(.or *(.str "\r\n", .str "\n"))
+def Lines = [<e> parser] parser->SplitByPattern(.or *(.str "\r\n", .str "\n"))
 
-def SplitBy = <e>[parser] [separator] parser->SplitByPattern(.str separator)
+def SplitBy = [<e> parser, separator] parser->SplitByPattern(.str separator)
 
-def SplitByPattern = <e>[parser] [separator] parser.begin.case {
+def SplitByPattern = [<e> parser, separator] parser.begin.case {
   .empty! => .end.ok!,
   .ready parser => parser.minMax(.repeat.one.any!, separator).case {
     .err e => .end.err e,
@@ -370,7 +370,7 @@ def Chars = [string] Parse(string).begin.case {
   } in .item(char) parser.loop,
 }
 
-def ReadAll = <e>[reader] ParseReader(reader)->Remainder
+def ReadAll = [<e> reader] ParseReader(reader)->Remainder
 
 // Helpers
 

--- a/crates/par-builtin/packages/core/src/Try.par
+++ b/crates/par-builtin/packages/core/src/Try.par
@@ -18,49 +18,49 @@ export {
   }
 
   // Extracts the `.ok` branch from a `Try<either {}, a>`.
-  dec Ok : <a>[Try<either {}, a>] a
+  dec Ok : [<a> Try<either {}, a>] a
 
   // Transforms the `.ok` value, if present.
-  dec Map : <e, a>[Try<e, a>] <b>[box [a] b] Try<e, b>
+  dec Map : [<e, a> Try<e, a>, <b> box [a] b] Try<e, b>
 
   // Transforms the `.err` value, if present.
-  dec MapErr : <e1, a>[Try<e1, a>] <e2>[box [e1] e2] Try<e2, a>
+  dec MapErr : [<e1, a> Try<e1, a>, <e2> box [e1] e2] Try<e2, a>
 
   // Transforms the `.ok` value with a computation that may itself fail.
-  dec FlatMap : <e, a>[Try<e, a>] <b>[box [a] Try<e, b>] Try<e, b>
+  dec FlatMap : [<e, a> Try<e, a>, <b> box [a] Try<e, b>] Try<e, b>
 
   // Keeps a successful value only if it satisfies the predicate, otherwise
   // replaces it with the provided error.
-  dec Filter : <e, a: box>[Try<e, a>] [box e, box [a] Bool] Try<e, a>
+  dec Filter : [<e, a: box> Try<e, a>, box e, box [a] Bool] Try<e, a>
 
   // Converts `.ok value` to a singleton list and `.err _` to an empty list.
-  dec ToList : <e: box, a>[Try<e, a>] List<a>
+  dec ToList : [<e: box, a> Try<e, a>] List<a>
 
   // Converts `.ok value` to `.some value` and `.err _` to `.none!`.
-  dec ToOption : <e: box, a>[Try<e, a>] Option<a>
+  dec ToOption : [<e: box, a> Try<e, a>] Option<a>
 }
 
-def Ok = <a>[result] result.case {
+def Ok = [<a> result] result.case {
   .ok value => value,
   .err impossible => impossible.case {},
 }
 
-def Map = <e, a>[result] <b>[f] result.case {
+def Map = [<e, a> result, <b> f] result.case {
   .ok a => .ok f(a),
   .err e => .err e,
 }
 
-def MapErr = <e1, a>[result] <e2>[f] result.case {
+def MapErr = [<e1, a> result, <e2> f] result.case {
   .ok a => .ok a,
   .err e => .err f(e),
 }
 
-def FlatMap = <e, a>[result] <b>[f] result.case {
+def FlatMap = [<e, a> result, <b> f] result.case {
   .ok a => f(a),
   .err e => .err e,
 }
 
-def Filter = <e, a: box>[result] [e1, p] result.case {
+def Filter = [<e, a: box> result, e1, p] result.case {
   .ok a => if {
     p(a) => .ok a,
     else => .err e1,
@@ -68,12 +68,12 @@ def Filter = <e, a: box>[result] [e1, p] result.case {
   .err e => .err e,
 }
 
-def ToList = <e: box, a>[result] result.case {
+def ToList = [<e: box, a> result] result.case {
   .ok a => .item(a) .end!,
   .err _ => .end!,
 }
 
-def ToOption = <e: box, a>[result] result.case {
+def ToOption = [<e: box, a> result] result.case {
   .ok a => .some a,
   .err _ => .none!,
 }

--- a/crates/par-core/src/frontend_impl/parse.rs
+++ b/crates/par-core/src/frontend_impl/parse.rs
@@ -965,7 +965,6 @@ fn typ(input: &mut Input) -> Result<Type<Unresolved>> {
         typ_self,
         typ_send,
         typ_receive,
-        typ_generic,
     ))
     .context(StrContext::Label("type"))
     .parse_next(input)
@@ -1021,7 +1020,7 @@ fn typ_send(input: &mut Input) -> Result<Type<Unresolved>> {
             items,
             then,
             |name, then| Type::Exists(span.clone(), name, Box::new(then)),
-            |arg, then| Type::Pair(span.clone(), Box::new(arg), Box::new(then), vec![]),
+            |vars, arg, then| Type::Pair(span.clone(), Box::new(arg), Box::new(then), vars),
         )
     })
     .parse_next(input)
@@ -1038,25 +1037,20 @@ fn typ_receive(input: &mut Input) -> Result<Type<Unresolved>> {
             items,
             then,
             |name, then| Type::Forall(span.clone(), name, Box::new(then)),
-            |arg, then| Type::Function(span.clone(), Box::new(arg), Box::new(then), vec![]),
+            |vars, arg, then| Type::Function(span.clone(), Box::new(arg), Box::new(then), vars),
         )
     })
     .parse_next(input)
 }
 
-enum SendOrReceive {
-    Send,
-    Receive,
-}
-
 enum TypePrefixItem {
     Explicit(TypeParameter),
-    Value(Type<Unresolved>),
+    Value(Vec<TypeParameter>, Type<Unresolved>),
 }
 
 enum PatternPrefixItem {
     Explicit(TypeParameter),
-    Value(Pattern<Unresolved>),
+    Value(Vec<TypeParameter>, Pattern<Unresolved>),
 }
 
 enum SendPrefixItem {
@@ -1068,11 +1062,11 @@ fn fold_type_prefix<T>(
     items: Vec<TypePrefixItem>,
     rest: T,
     mut explicit: impl FnMut(TypeParameter, T) -> T,
-    mut value: impl FnMut(Type<Unresolved>, T) -> T,
+    mut value: impl FnMut(Vec<TypeParameter>, Type<Unresolved>, T) -> T,
 ) -> T {
     items.into_iter().rfold(rest, |rest, item| match item {
         TypePrefixItem::Explicit(name) => explicit(name, rest),
-        TypePrefixItem::Value(typ) => value(typ, rest),
+        TypePrefixItem::Value(vars, typ) => value(vars, typ, rest),
     })
 }
 
@@ -1116,10 +1110,17 @@ fn explicit_type_parameter(input: &mut Input) -> Result<TypeParameter> {
         .parse_next(input)
 }
 
+fn implicit_type_parameters(input: &mut Input) -> Result<Vec<TypeParameter>> {
+    commit_after(t(TokenKind::Lt), (list1(type_parameter), t(TokenKind::Gt)))
+        .map(|(_, (parameters, _))| parameters)
+        .parse_next(input)
+}
+
 fn type_prefix_item(input: &mut Input) -> Result<TypePrefixItem> {
     alt((
         explicit_type_parameter.map(TypePrefixItem::Explicit),
-        typ.map(TypePrefixItem::Value),
+        (opt(implicit_type_parameters), typ)
+            .map(|(vars, typ)| TypePrefixItem::Value(vars.unwrap_or_default(), typ)),
     ))
     .parse_next(input)
 }
@@ -1127,7 +1128,8 @@ fn type_prefix_item(input: &mut Input) -> Result<TypePrefixItem> {
 fn pattern_prefix_item(input: &mut Input) -> Result<PatternPrefixItem> {
     alt((
         explicit_type_parameter.map(PatternPrefixItem::Explicit),
-        pattern.map(PatternPrefixItem::Value),
+        (opt(implicit_type_parameters), pattern)
+            .map(|(vars, pattern)| PatternPrefixItem::Value(vars.unwrap_or_default(), pattern)),
     ))
     .parse_next(input)
 }
@@ -1147,53 +1149,6 @@ fn send_prefix_item(close: TokenKind, input: &mut Input) -> Result<SendPrefixIte
     }
 
     expression.map(SendPrefixItem::Value).parse_next(input)
-}
-
-fn typ_simple_send(
-    input: &mut Input,
-) -> Result<(SendOrReceive, Type<Unresolved>, Type<Unresolved>, Span)> {
-    commit_after(t(TokenKind::LParen), (typ, t(TokenKind::RParen), typ))
-        .map(|(open, (arg, close, then))| {
-            let span = open.span.join(close.span());
-            (SendOrReceive::Send, arg, then, span)
-        })
-        .parse_next(input)
-}
-
-fn typ_simple_receive(
-    input: &mut Input,
-) -> Result<(SendOrReceive, Type<Unresolved>, Type<Unresolved>, Span)> {
-    commit_after(t(TokenKind::LBrack), (typ, t(TokenKind::RBrack), typ))
-        .map(|(open, (arg, close, then))| {
-            let span = open.span.join(close.span());
-            (SendOrReceive::Receive, arg, then, span)
-        })
-        .parse_next(input)
-}
-
-fn typ_generic(input: &mut Input) -> Result<Type<Unresolved>> {
-    commit_after(
-        t(TokenKind::Lt),
-        (
-            list1(type_parameter),
-            t(TokenKind::Gt),
-            alt((typ_simple_send, typ_simple_receive)),
-        ),
-    )
-    .map(
-        |(vars_open, (vars, _vars_close, (snd_or_recv, arg, then, span)))| {
-            let span = vars_open.span.join(span);
-            match snd_or_recv {
-                SendOrReceive::Send => {
-                    Type::Pair(span.clone(), Box::new(arg), Box::new(then), vars)
-                }
-                SendOrReceive::Receive => {
-                    Type::Function(span.clone(), Box::new(arg), Box::new(then), vars)
-                }
-            }
-        },
-    )
-    .parse_next(input)
 }
 
 fn typ_either(input: &mut Input) -> Result<Type<Unresolved>> {
@@ -1307,7 +1262,7 @@ fn typ_branch_receive(input: &mut Input) -> Result<Type<Unresolved>> {
             items,
             then,
             |name, then| Type::Forall(span.clone(), name, Box::new(then)),
-            |arg, then| Type::Function(span.clone(), Box::new(arg), Box::new(then), vec![]),
+            |vars, arg, then| Type::Function(span.clone(), Box::new(arg), Box::new(then), vars),
         )
     })
     .parse_next(input)
@@ -1326,7 +1281,6 @@ fn pattern(input: &mut Input) -> Result<Pattern<Unresolved>> {
         match alt((
             pattern_name,
             pattern_receive,
-            pattern_generic_receive,
             pattern_continue,
             pattern_default,
             pattern_try,
@@ -1373,33 +1327,13 @@ fn pattern_receive(input: &mut Input) -> Result<PatternPiece> {
                     PatternPrefixItem::Explicit(name) => {
                         PatternStep::ReceiveType(span.clone(), name)
                     }
-                    PatternPrefixItem::Value(pattern) => {
-                        PatternStep::Receive(span.clone(), Box::new(pattern), vec![])
+                    PatternPrefixItem::Value(vars, pattern) => {
+                        PatternStep::Receive(span.clone(), Box::new(pattern), vars)
                     }
                 })
                 .collect(),
         )
     })
-    .parse_next(input)
-}
-
-fn pattern_generic_receive(input: &mut Input) -> Result<PatternPiece> {
-    commit_after(
-        t(TokenKind::Lt),
-        (
-            list1(type_parameter),
-            t(TokenKind::Gt),
-            t(TokenKind::LParen),
-            pattern,
-            t(TokenKind::RParen),
-        ),
-    )
-    .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
-            let span = vars_open.span.join(pattern_close.span());
-            PatternPiece::Steps(vec![PatternStep::Receive(span, Box::new(arg), vars)])
-        },
-    )
     .parse_next(input)
 }
 
@@ -2187,7 +2121,6 @@ fn parse_construction(
                 cons_break,
                 cons_send,
                 cons_receive,
-                cons_generic_receive,
             ))
             .context(StrContext::Label("construction"))
             .parse_next(input)?
@@ -2272,36 +2205,13 @@ fn cons_receive(input: &mut Input) -> Result<ConstructionPiece> {
                     PatternPrefixItem::Explicit(name) => {
                         ConstructStep::ReceiveType(short_span.clone(), name)
                     }
-                    PatternPrefixItem::Value(pattern) => {
-                        ConstructStep::Receive(short_span.clone(), pattern, vec![])
+                    PatternPrefixItem::Value(vars, pattern) => {
+                        ConstructStep::Receive(short_span.clone(), pattern, vars)
                     }
                 })
                 .collect(),
         )
     })
-    .parse_next(input)
-}
-
-fn cons_generic_receive(input: &mut Input) -> Result<ConstructionPiece> {
-    commit_after(
-        t(TokenKind::Lt),
-        (
-            list1(type_parameter),
-            t(TokenKind::Gt),
-            t(TokenKind::LBrack),
-            pattern,
-            t(TokenKind::RBrack),
-        ),
-    )
-    .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
-            let short_span = vars_open.span.join(pattern_close.span());
-            ConstructionPiece::Steps(
-                short_span.clone(),
-                vec![ConstructStep::Receive(short_span, arg, vars)],
-            )
-        },
-    )
     .parse_next(input)
 }
 
@@ -2421,13 +2331,7 @@ fn cons_submit(input: &mut Input) -> Result<ConstructionPiece> {
 fn cons_branch(input: &mut Input) -> Result<ConstructBranch<Unresolved>> {
     let mut steps = Vec::new();
     loop {
-        match alt((
-            cons_branch_then,
-            cons_branch_receive,
-            cons_branch_generic_receive,
-        ))
-        .parse_next(input)?
-        {
+        match alt((cons_branch_then, cons_branch_receive)).parse_next(input)? {
             ConstructBranchPiece::Steps(mut parsed) => steps.append(&mut parsed),
             ConstructBranchPiece::Terminator(terminator) => {
                 return Ok(ConstructBranch { steps, terminator });
@@ -2466,33 +2370,13 @@ fn cons_branch_receive(input: &mut Input) -> Result<ConstructBranchPiece> {
                     PatternPrefixItem::Explicit(name) => {
                         ConstructBranchStep::ReceiveType(span.clone(), name)
                     }
-                    PatternPrefixItem::Value(pattern) => {
-                        ConstructBranchStep::Receive(span.clone(), pattern, vec![])
+                    PatternPrefixItem::Value(vars, pattern) => {
+                        ConstructBranchStep::Receive(span.clone(), pattern, vars)
                     }
                 })
                 .collect(),
         )
     })
-    .parse_next(input)
-}
-
-fn cons_branch_generic_receive(input: &mut Input) -> Result<ConstructBranchPiece> {
-    commit_after(
-        t(TokenKind::Lt),
-        (
-            list1(type_parameter),
-            t(TokenKind::Gt),
-            t(TokenKind::LParen),
-            pattern,
-            t(TokenKind::RParen),
-        ),
-    )
-    .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
-            let span = vars_open.span.join(pattern_close.span());
-            ConstructBranchPiece::Steps(vec![ConstructBranchStep::Receive(span, arg, vars)])
-        },
-    )
     .parse_next(input)
 }
 
@@ -2768,7 +2652,6 @@ fn apply_branch(input: &mut Input) -> Result<ApplyBranch<Unresolved>> {
         match alt((
             apply_branch_then,
             apply_branch_receive,
-            apply_branch_generic_receive,
             apply_branch_continue,
             apply_branch_try,
             apply_branch_default,
@@ -2814,33 +2697,13 @@ fn apply_branch_receive(input: &mut Input) -> Result<ApplyBranchPiece> {
                     PatternPrefixItem::Explicit(name) => {
                         ApplyBranchStep::ReceiveType(span.clone(), name)
                     }
-                    PatternPrefixItem::Value(pattern) => {
-                        ApplyBranchStep::Receive(span.clone(), pattern, vec![])
+                    PatternPrefixItem::Value(vars, pattern) => {
+                        ApplyBranchStep::Receive(span.clone(), pattern, vars)
                     }
                 })
                 .collect(),
         )
     })
-    .parse_next(input)
-}
-
-fn apply_branch_generic_receive(input: &mut Input) -> Result<ApplyBranchPiece> {
-    commit_after(
-        t(TokenKind::Lt),
-        (
-            list1(type_parameter),
-            t(TokenKind::Gt),
-            t(TokenKind::LParen),
-            pattern,
-            t(TokenKind::RParen),
-        ),
-    )
-    .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
-            let span = vars_open.span.join(pattern_close.span());
-            ApplyBranchPiece::Steps(vec![ApplyBranchStep::Receive(span, arg, vars)])
-        },
-    )
     .parse_next(input)
 }
 
@@ -3532,7 +3395,6 @@ fn cmd(input: &mut Input) -> Result<Option<(Span, Command<Unresolved>)>> {
             cmd_continue,
             cmd_send,
             cmd_receive,
-            cmd_generic_receive,
             cmd_try,
             cmd_default,
             cmd_pipe,
@@ -3644,36 +3506,13 @@ fn cmd_receive(input: &mut Input) -> Result<CommandPiece> {
                 PatternPrefixItem::Explicit(name) => {
                     CommandStep::ReceiveType(short_span.clone(), name)
                 }
-                PatternPrefixItem::Value(pattern) => {
-                    CommandStep::Receive(short_span.clone(), pattern, vec![])
+                PatternPrefixItem::Value(vars, pattern) => {
+                    CommandStep::Receive(short_span.clone(), pattern, vars)
                 }
             })
             .collect();
         CommandPiece::Steps(short_span, steps)
     })
-    .parse_next(input)
-}
-
-fn cmd_generic_receive(input: &mut Input) -> Result<CommandPiece> {
-    commit_after(
-        t(TokenKind::Lt),
-        (
-            list1(type_parameter),
-            t(TokenKind::Gt),
-            t(TokenKind::LBrack),
-            pattern,
-            t(TokenKind::RBrack),
-        ),
-    )
-    .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
-            let short_span = vars_open.span.join(pattern_close.span());
-            CommandPiece::Steps(
-                short_span.clone(),
-                vec![CommandStep::Receive(short_span, arg, vars)],
-            )
-        },
-    )
     .parse_next(input)
 }
 
@@ -3856,7 +3695,6 @@ fn cmd_branch(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
             cmd_branch_bind_then,
             cmd_branch_continue,
             cmd_branch_receive,
-            cmd_branch_generic_receive,
             cmd_branch_try,
             cmd_branch_default,
         ))
@@ -3927,33 +3765,13 @@ fn cmd_branch_receive(input: &mut Input) -> Result<CommandBranchPiece> {
                     PatternPrefixItem::Explicit(name) => {
                         CommandBranchStep::ReceiveType(span.clone(), name)
                     }
-                    PatternPrefixItem::Value(pattern) => {
-                        CommandBranchStep::Receive(span.clone(), pattern, vec![])
+                    PatternPrefixItem::Value(vars, pattern) => {
+                        CommandBranchStep::Receive(span.clone(), pattern, vars)
                     }
                 })
                 .collect(),
         )
     })
-    .parse_next(input)
-}
-
-fn cmd_branch_generic_receive(input: &mut Input) -> Result<CommandBranchPiece> {
-    commit_after(
-        t(TokenKind::Lt),
-        (
-            list1(type_parameter),
-            t(TokenKind::Gt),
-            t(TokenKind::LParen),
-            pattern,
-            t(TokenKind::RParen),
-        ),
-    )
-    .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
-            let span = vars_open.span.join(pattern_close.span());
-            CommandBranchPiece::Steps(vec![CommandBranchStep::Receive(span, arg, vars)])
-        },
-    )
     .parse_next(input)
 }
 
@@ -4551,11 +4369,105 @@ def SendTypeData = (type Bool) .true! and .false!
 module Minimal
 
 dec Explicit : [type a: number, (a) !] !
-dec Implicit : <a: signed>[a] a
+dec Implicit : [<a: signed> a] a
 def Explicit = [type a: number, p] !
-def Implicit = <a: signed>[x] x
+def Implicit = [<a: signed> x] x
 ";
         assert!(parse_module(source, "minimal.par".into()).is_ok());
+    }
+
+    #[test]
+    fn test_parse_implicit_generic_items() {
+        let source = "\
+module Minimal
+
+dec Mixed : [type explicit, Nat, <a, b: box> (a) b, String, <c> c] (Nat, <d: data> d, <e> e)!
+def Mixed = [type explicit, n, <a, b: box> pair: (a) b, text: String, <c> value: c] (n, value)!
+";
+        let parsed = parse_source_file(source, "Minimal.par".into()).unwrap();
+        let typ = &parsed.body.declarations[0].typ;
+
+        let Type::Forall(_, explicit, typ) = typ else {
+            panic!("expected explicit type item: {typ:#?}");
+        };
+        assert_eq!(explicit.name.string.as_str(), "explicit");
+
+        let Type::Function(_, _, typ, vars) = typ.as_ref() else {
+            panic!("expected ordinary function item: {typ:#?}");
+        };
+        assert!(vars.is_empty());
+
+        let Type::Function(_, _, typ, vars) = typ.as_ref() else {
+            panic!("expected implicit function item: {typ:#?}");
+        };
+        assert_eq!(vars.len(), 2);
+        assert_eq!(vars[0].name.string.as_str(), "a");
+        assert_eq!(vars[1].name.string.as_str(), "b");
+        assert_eq!(vars[1].constraint, TypeConstraint::Box);
+
+        let Type::Function(_, _, typ, vars) = typ.as_ref() else {
+            panic!("expected second ordinary function item: {typ:#?}");
+        };
+        assert!(vars.is_empty());
+
+        let Type::Function(_, _, typ, vars) = typ.as_ref() else {
+            panic!("expected second implicit function item: {typ:#?}");
+        };
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].name.string.as_str(), "c");
+
+        let Type::Pair(_, _, typ, vars) = typ.as_ref() else {
+            panic!("expected ordinary pair item: {typ:#?}");
+        };
+        assert!(vars.is_empty());
+
+        let Type::Pair(_, _, typ, vars) = typ.as_ref() else {
+            panic!("expected implicit pair item: {typ:#?}");
+        };
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].name.string.as_str(), "d");
+        assert_eq!(vars[0].constraint, TypeConstraint::Data);
+
+        let Type::Pair(_, _, _, vars) = typ.as_ref() else {
+            panic!("expected second implicit pair item: {typ:#?}");
+        };
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].name.string.as_str(), "e");
+    }
+
+    #[test]
+    fn test_parse_implicit_existential_patterns_and_branches() {
+        let source = "\
+module Minimal
+
+type Packed = (Nat, <a: data> a)!
+type Tagged = either { .dat(<a: data> a)!, }
+
+def Unpack = [packed]
+  let (n, <a: data> value)! = packed
+  in (n, value)!
+
+def Match = [tagged] tagged.case {
+  .dat(<a: data> value)! => value,
+}
+
+def CommandMatch = [tagged] do {
+  tagged.case {
+    .dat(<a: data> value)! => {}
+  }
+} in !
+";
+        assert!(parse_module(source, "Minimal.par".into()).is_ok());
+    }
+
+    #[test]
+    fn test_reject_old_implicit_generic_prefix_syntax() {
+        let function = "module Minimal\n\ndec Old : <a>[a] a\n";
+        let pair = "module Minimal\n\ntype Old = <a>(a)!\n";
+        assert!(parse_module(function, "Minimal.par".into()).is_err());
+        assert!(parse_module(pair, "Minimal.par".into()).is_err());
+        assert_definition_rejected("<a>[x] x");
+        assert_definition_rejected("[value] value.case { .dat<a>(x)! => x }");
     }
 
     #[test]

--- a/crates/par-core/src/frontend_impl/parse.rs
+++ b/crates/par-core/src/frontend_impl/parse.rs
@@ -3847,14 +3847,6 @@ mod test {
         );
     }
 
-    fn assert_definition_rejected(body: &str) {
-        let source = format!("module Main\n\ndef Value = {body}\n");
-        assert!(
-            parse_module(&source, "Main.par".into()).is_err(),
-            "unexpectedly parsed definition body: {body}"
-        );
-    }
-
     #[test]
     fn test_parse_examples() {
         let input = include_str!(concat!(
@@ -4023,21 +4015,6 @@ def Value = 1 + 2 * 3
             "value->Module.F(arg).case { .some x => x, .none! => 0 }",
         ] {
             assert_definition_parses(body);
-        }
-    }
-
-    #[test]
-    fn test_reject_revamped_expression_boundaries() {
-        for body in [
-            "1 + if { .true! => 2, else => 3 }",
-            "if { .true! => 1, else => 2 }->Id",
-            ".true!.case { .true! => 1, .false! => 0 }",
-            ".true!->Id",
-            "n->box [x] x",
-            "submit(xs)->Id",
-            "loop->Id",
-        ] {
-            assert_definition_rejected(body);
         }
     }
 
@@ -4458,16 +4435,6 @@ def CommandMatch = [tagged] do {
 } in !
 ";
         assert!(parse_module(source, "Minimal.par".into()).is_ok());
-    }
-
-    #[test]
-    fn test_reject_old_implicit_generic_prefix_syntax() {
-        let function = "module Minimal\n\ndec Old : <a>[a] a\n";
-        let pair = "module Minimal\n\ntype Old = <a>(a)!\n";
-        assert!(parse_module(function, "Minimal.par".into()).is_err());
-        assert!(parse_module(pair, "Minimal.par".into()).is_err());
-        assert_definition_rejected("<a>[x] x");
-        assert_definition_rejected("[value] value.case { .dat<a>(x)! => x }");
     }
 
     #[test]

--- a/crates/par-core/src/frontend_impl/process.rs
+++ b/crates/par-core/src/frontend_impl/process.rs
@@ -1684,14 +1684,15 @@ impl<Typ, S: Clone + std::fmt::Display> Command<Typ, S> {
                 write!(f, ")")
             }
             Command::Receive(parameter, _, _, vars) => {
+                write!(f, "[")?;
                 if !vars.is_empty() {
                     write!(f, "<{}", vars[0])?;
                     for var in &vars[1..] {
                         write!(f, ", {}", var)?;
                     }
-                    write!(f, ">")?;
+                    write!(f, "> ")?;
                 }
-                write!(f, "[{}]", parameter)
+                write!(f, "{}]", parameter)
             }
             Command::Signal(chosen) => write!(f, ".{}", chosen),
             Command::Continue => write!(f, "?"),
@@ -1769,5 +1770,25 @@ struct CanonicalGlobalNameWriter;
 impl<S: std::fmt::Display> GlobalNameWriter<S> for CanonicalGlobalNameWriter {
     fn write_global_name<W: Write>(&self, f: &mut W, name: &GlobalName<S>) -> fmt::Result {
         write!(f, "{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frontend_impl::language::Unresolved;
+    use arcstr::literal;
+
+    #[test]
+    fn implicit_receive_parameters_render_inside_brackets() {
+        let command = Command::<(), Unresolved>::Receive(
+            LocalName::from(literal!("value")),
+            None,
+            (),
+            vec![TypeParameter::any(LocalName::from(literal!("a")))],
+        );
+        let mut rendered = String::new();
+        command.pretty(&mut rendered, 0).unwrap();
+        assert_eq!(rendered, "[<a> value]");
     }
 }

--- a/crates/par-core/src/frontend_impl/types/display.rs
+++ b/crates/par-core/src/frontend_impl/types/display.rs
@@ -327,62 +327,54 @@ fn write_pair_like<S: Clone, N: GlobalNameWriter<S>>(
     let mut then = typ;
     let mut wrote_prefix_item = false;
 
-    match typ {
-        Type::Function(_, arg, next_then, vars) if function && !vars.is_empty() => {
-            write!(f, "<{}", vars[0])?;
-            for var in vars.iter().skip(1) {
-                write!(f, ", {var}")?;
-            }
-            write!(f, ">{open}")?;
-            write_type_with_options(f, names, arg, options)?;
-            then = next_then;
-        }
-        Type::Pair(_, arg, next_then, vars) if !function && !vars.is_empty() => {
-            write!(f, "<{}", vars[0])?;
-            for var in vars.iter().skip(1) {
-                write!(f, ", {var}")?;
-            }
-            write!(f, ">{open}")?;
-            write_type_with_options(f, names, arg, options)?;
-            then = next_then;
-        }
-        _ => {
-            write!(f, "{open}")?;
-            loop {
-                match then {
-                    Type::Forall(_, name, next_then) if function => {
-                        if wrote_prefix_item {
-                            write!(f, ", ")?;
-                        }
-                        write!(f, "type {name}")?;
-                        then = next_then;
-                    }
-                    Type::Exists(_, name, next_then) if !function => {
-                        if wrote_prefix_item {
-                            write!(f, ", ")?;
-                        }
-                        write!(f, "type {name}")?;
-                        then = next_then;
-                    }
-                    Type::Function(_, arg, next_then, vars) if function && vars.is_empty() => {
-                        if wrote_prefix_item {
-                            write!(f, ", ")?;
-                        }
-                        write_type_with_options(f, names, arg, options)?;
-                        then = next_then;
-                    }
-                    Type::Pair(_, arg, next_then, vars) if !function && vars.is_empty() => {
-                        if wrote_prefix_item {
-                            write!(f, ", ")?;
-                        }
-                        write_type_with_options(f, names, arg, options)?;
-                        then = next_then;
-                    }
-                    _ => break,
+    write!(f, "{open}")?;
+    loop {
+        match then {
+            Type::Forall(_, name, next_then) if function => {
+                if wrote_prefix_item {
+                    write!(f, ", ")?;
                 }
-                wrote_prefix_item = true;
+                write!(f, "type {name}")?;
+                then = next_then;
             }
+            Type::Exists(_, name, next_then) if !function => {
+                if wrote_prefix_item {
+                    write!(f, ", ")?;
+                }
+                write!(f, "type {name}")?;
+                then = next_then;
+            }
+            Type::Function(_, arg, next_then, vars) if function => {
+                if wrote_prefix_item {
+                    write!(f, ", ")?;
+                }
+                if !vars.is_empty() {
+                    write!(f, "<{}", vars[0])?;
+                    for var in vars.iter().skip(1) {
+                        write!(f, ", {var}")?;
+                    }
+                    write!(f, "> ")?;
+                }
+                write_type_with_options(f, names, arg, options)?;
+                then = next_then;
+            }
+            Type::Pair(_, arg, next_then, vars) if !function => {
+                if wrote_prefix_item {
+                    write!(f, ", ")?;
+                }
+                if !vars.is_empty() {
+                    write!(f, "<{}", vars[0])?;
+                    for var in vars.iter().skip(1) {
+                        write!(f, ", {var}")?;
+                    }
+                    write!(f, "> ")?;
+                }
+                write_type_with_options(f, names, arg, options)?;
+                then = next_then;
+            }
+            _ => break,
         }
+        wrote_prefix_item = true;
     }
 
     let is_terminal = if function {
@@ -421,8 +413,7 @@ fn write_braced_branches<S: Clone, N: GlobalNameWriter<S>>(
         options.write_indentation(f)?;
         write!(f, ".{branch}")?;
         if choice {
-            if matches!(branch_type, Type::Function(.., vars) if vars.is_empty())
-                || matches!(branch_type, Type::Forall(..))
+            if matches!(branch_type, Type::Function(..)) || matches!(branch_type, Type::Forall(..))
             {
                 write_pair_like(f, names, "(", ") =>", branch_type, true, options)?;
             } else {
@@ -430,9 +421,10 @@ fn write_braced_branches<S: Clone, N: GlobalNameWriter<S>>(
                 write_type_with_options(f, names, branch_type, options)?;
             }
         } else {
-            if matches!(branch_type, Type::Break(_) | Type::Exists(..))
-                || matches!(branch_type, Type::Pair(.., vars) if vars.is_empty())
-            {
+            if matches!(
+                branch_type,
+                Type::Break(_) | Type::Exists(..) | Type::Pair(..)
+            ) {
                 // no space between `.foo` and `!`/`(`
             } else {
                 write!(f, " ")?;

--- a/crates/par-core/src/frontend_impl/types/tests.rs
+++ b/crates/par-core/src/frontend_impl/types/tests.rs
@@ -283,6 +283,91 @@ mod tests {
     }
 
     #[test]
+    fn test_implicit_generic_items_render_inside_pair_like_delimiters() {
+        let parameter = |name: &str, constraint| TypeParameter {
+            name: LocalName {
+                span: Span::None,
+                string: ArcStr::from(name),
+            },
+            constraint,
+        };
+
+        let function = Type::<Universal>::Function(
+            Span::None,
+            Box::new(Type::var("a")),
+            Box::new(Type::Function(
+                Span::None,
+                Box::new(Type::string()),
+                Box::new(Type::Function(
+                    Span::None,
+                    Box::new(Type::var("b")),
+                    Box::new(Type::int()),
+                    vec![parameter("b", TypeConstraint::Box)],
+                )),
+                vec![],
+            )),
+            vec![parameter("a", TypeConstraint::Any)],
+        );
+        let mut rendered = String::new();
+        function
+            .pretty_compact(&mut rendered, &TestNameWriter)
+            .unwrap();
+        assert_eq!(rendered, "[<a> a, String, <b: box> b] Int");
+
+        let pair = Type::<Universal>::Pair(
+            Span::None,
+            Box::new(Type::nat()),
+            Box::new(Type::Pair(
+                Span::None,
+                Box::new(Type::var("a")),
+                Box::new(Type::Pair(
+                    Span::None,
+                    Box::new(Type::string()),
+                    Box::new(Type::break_()),
+                    vec![],
+                )),
+                vec![parameter("a", TypeConstraint::Data)],
+            )),
+            vec![],
+        );
+        rendered.clear();
+        pair.pretty_compact(&mut rendered, &TestNameWriter).unwrap();
+        assert_eq!(rendered, "(Nat, <a: data> a, String)!");
+    }
+
+    #[test]
+    fn test_implicit_generic_branch_items_render_compactly() {
+        let parameter = TypeParameter::any(LocalName {
+            span: Span::None,
+            string: ArcStr::from("a"),
+        });
+        let pair = Type::<Universal>::Pair(
+            Span::None,
+            Box::new(Type::var("a")),
+            Box::new(Type::break_()),
+            vec![parameter.clone()],
+        );
+        let function = Type::<Universal>::Function(
+            Span::None,
+            Box::new(Type::var("a")),
+            Box::new(Type::break_()),
+            vec![parameter],
+        );
+
+        let mut rendered = String::new();
+        Type::either(vec![("dat", pair)])
+            .pretty_compact(&mut rendered, &TestNameWriter)
+            .unwrap();
+        assert_eq!(rendered, "either {.dat(<a> a)!,}");
+
+        rendered.clear();
+        Type::choice(vec![("use", function)])
+            .pretty_compact(&mut rendered, &TestNameWriter)
+            .unwrap();
+        assert_eq!(rendered, "choice {.use(<a> a) => !,}");
+    }
+
+    #[test]
     fn test_pretty_compact_keeps_named_fixpoint_aliases_after_expansion() {
         let (defs, map_name) = alias_preserving_type_defs();
         let expanded = defs

--- a/crates/par-core/src/workspace.rs
+++ b/crates/par-core/src/workspace.rs
@@ -2970,7 +2970,7 @@ def Identity = [type a: number, x: a] x
         let source = "\
 module Main
 
-def SignedId : <a: signed>[a] a = <a: signed>[x] x
+def SignedId : [<a: signed> a] a = [<a: signed> x] x
 def Result = SignedId(5)
 ";
         let checked = checked_workspace_from_source(source);
@@ -2983,6 +2983,51 @@ def Result = SignedId(5)
             .unwrap();
 
         assert_eq!(checked.render_type_in_file(file, typ, 0), "Int");
+    }
+
+    #[test]
+    fn separate_implicit_items_infer_from_their_own_arguments() {
+        let source = "\
+module Main
+
+def ChooseSecond : [<a: box> a, <b> b] b = [<a: box> first, <b> second] second
+def Result = ChooseSecond(5, \"chosen\")
+";
+        let checked = checked_workspace_from_source(source);
+        let file = checked.workspace().sources().keys().next().unwrap();
+        let (_name, (_definition, typ)) = checked
+            .checked_module()
+            .definitions
+            .iter()
+            .find(|(name, _)| name.primary == "Result")
+            .unwrap();
+
+        assert_eq!(checked.render_type_in_file(file, typ, 0), "String");
+    }
+
+    #[test]
+    fn implicit_existential_item_infers_and_exposes_its_hidden_type() {
+        let source = "\
+module Main
+
+type Packed = (<a: box> a)!
+
+def PackedUnit : Packed = (!)!
+def Unpack : [Packed] ! = [packed]
+  let (<a: box> value)! = packed
+  in !
+def Result = Unpack(PackedUnit)
+";
+        let checked = checked_workspace_from_source(source);
+        let file = checked.workspace().sources().keys().next().unwrap();
+        let (_name, (_definition, typ)) = checked
+            .checked_module()
+            .definitions
+            .iter()
+            .find(|(name, _)| name.primary == "Result")
+            .unwrap();
+
+        assert_eq!(checked.render_type_in_file(file, typ, 0), "!");
     }
 
     #[test]

--- a/docs/src/nondeterminism/both_ways.md
+++ b/docs/src/nondeterminism/both_ways.md
@@ -30,7 +30,7 @@ type ListFan<a> = recursive either {
 We used it for merging `List<List<a>>`, but nothing prevents us from using it standalone as well:
 
 ```par
-dec ServeListFan : <a>[ListFan<a>] List<a>
+dec ServeListFan : [<a> ListFan<a>] List<a>
 def ServeListFan = ...
 ```
 
@@ -225,8 +225,8 @@ To implement such a server, we need to decide what to do with the value once all
 ```par
 type MutexClient<a> = dual MutexServer<a>
 
-dec ShareMutex : <a>[a] [MutexClient<a>] a
-def ShareMutex = <a>[value] [clients] poll(clients) {
+dec ShareMutex : [<a> a, MutexClient<a>] a
+def ShareMutex = [<a> value, clients] poll(clients) {
   client => client.case {
     .end! => submit(),
     .spawn(l) r => submit(l, r),

--- a/docs/src/nondeterminism/fan_pattern.md
+++ b/docs/src/nondeterminism/fan_pattern.md
@@ -7,8 +7,8 @@ module Main
 
 import @core/List
 
-dec MergeTwoLists : <a>[List<a>] [List<a>] List<a>
-def MergeTwoLists = <a>[left] [right] poll(left, right) {
+dec MergeTwoLists : [<a> List<a>, List<a>] List<a>
+def MergeTwoLists = [<a> left, right] poll(left, right) {
   list => list.case {
     .end! => submit(),
     .item(x) xs => .item(x) submit(xs),
@@ -20,8 +20,8 @@ def MergeTwoLists = <a>[left] [right] poll(left, right) {
 And also a tree:
 
 ```par
-dec TreeToList : <a>[Tree<a>] List<a>
-def TreeToList = <a>[tree] poll(tree) {
+dec TreeToList : [<a> Tree<a>] List<a>
+def TreeToList = [<a> tree] poll(tree) {
   tree => tree.case {
     .leaf x => .item(x) submit(),
     .node(l) r => submit(l, r),
@@ -35,7 +35,7 @@ Merging multiple sources of information this way is great when you need to aggre
 **What about merging a list of lists?**
 
 ```par
-dec MergeLists : <a>[List<List<a>>] List<a>
+dec MergeLists : [<a> List<List<a>>] List<a>
 def MergeLists = ???
 ```
 
@@ -46,8 +46,8 @@ That's because a pool requires all its clients to be of the same type. But if we
 > We can actually solve this by combining `poll`/`submit` with `.begin`/`.loop`.
 >
 > ```par
-> dec MergeLists : <a>[List<List<a>>] List<a>
-> def MergeLists = <a>[lists] lists.begin.case {
+> dec MergeLists : [<a> List<List<a>>] List<a>
+> def MergeLists = [<a> lists] lists.begin.case {
 >   .end! => .end!,
 >   .item(list) lists => poll(list, lists.loop) {
 >     list => list.case {
@@ -123,8 +123,8 @@ They allow the structure to **dynamically spread into multiple agents,** while t
 The transformation is quite simple:
 
 ```par
-dec ListFan : <a>[List<List<a>>] ListFan<a>
-def ListFan = <a>[lists] lists.begin.case {
+dec ListFan : [<a> List<List<a>>] ListFan<a>
+def ListFan = [<a> lists] lists.begin.case {
   .end! => .end!,
   .item(list) lists => .spawn(
     list.begin.case {
@@ -149,8 +149,8 @@ It consists of two nested recursions.
 **Now, we're able to implement `MergeLists` easily:**
 
 ```par
-dec MergeLists : <a>[List<List<a>>] List<a>
-def MergeLists = <a>[lists] poll(ListFan(lists)) {
+dec MergeLists : [<a> List<List<a>>] List<a>
+def MergeLists = [<a> lists] poll(ListFan(lists)) {
   fan => fan.case {
     .end! => submit(),
     .spawn(l) r => submit(l, r),

--- a/docs/src/nondeterminism/poll_submit.md
+++ b/docs/src/nondeterminism/poll_submit.md
@@ -151,8 +151,8 @@ The empty `submit()` in the `.end!` branch now makes sense! Just because one of 
 **Let's now merge two lists into one:**
 
 ```par
-dec MergeTwoLists : <a>[List<a>] [List<a>] List<a>
-def MergeTwoLists = <a>[left] [right] poll(left, right) {
+dec MergeTwoLists : [<a> List<a>, List<a>] List<a>
+def MergeTwoLists = [<a> left, right] poll(left, right) {
   list => list.case {
     .end! => submit(),
     .item(x) xs => .item(x) submit(xs),
@@ -188,8 +188,8 @@ type Tree<a> = recursive either {
 Works like a charm:
 
 ```par
-dec TreeToList : <a>[Tree<a>] List<a>
-def TreeToList = <a>[tree] poll(tree) {
+dec TreeToList : [<a> Tree<a>] List<a>
+def TreeToList = [<a> tree] poll(tree) {
   tree => tree.case {
     .leaf x => .item(x) submit(),
     .node(l) r => submit(l, r),

--- a/docs/src/nondeterminism/repoll.md
+++ b/docs/src/nondeterminism/repoll.md
@@ -65,7 +65,7 @@ Here, the source can make progress on its own (it can produce `.item` or `.end!`
 Now suppose we have many sources, and we want to merge them into one:
 
 ```par
-dec MergeSources : <a>[List<Source<a>>] Source<a>
+dec MergeSources : [<a> List<Source<a>>] Source<a>
 ```
 
 When the merged source is canceled, all underlying sources must be canceled too. That means our server needs two distinct modes:
@@ -114,8 +114,8 @@ type SourceFan<a> = recursive either {
   }
 }
 
-dec SourceFan : <a>[List<Source<a>>] SourceFan<a>
-def SourceFan = <a>[sources] sources.begin.case {
+dec SourceFan : [<a> List<Source<a>>] SourceFan<a>
+def SourceFan = [<a> sources] sources.begin.case {
   .end! => .end!,
   .item(source) sources => .spawn(source) sources.loop,
 }
@@ -124,7 +124,7 @@ def SourceFan = <a>[sources] sources.begin.case {
 Now we can implement:
 
 ```par
-dec MergeSources : <a>[List<Source<a>>] Source<a>
+dec MergeSources : [<a> List<Source<a>>] Source<a>
 ```
 
 The key idea is that `MergeSources` has two modes:
@@ -134,7 +134,7 @@ The key idea is that `MergeSources` has two modes:
 Here's the overall structure:
 
 ```par
-def MergeSources = <a>[sources] poll(SourceFan(sources)) {
+def MergeSources = [<a> sources] poll(SourceFan(sources)) {
   fan => fan.case {
     .end! => submit(),
     .spawn(l) r => submit(l, r),
@@ -200,8 +200,8 @@ module Main
 
 import @core/List
 
-dec MergeSources : <a>[List<Source<a>>] Source<a>
-def MergeSources = <a>[sources] poll(SourceFan(sources)) {
+dec MergeSources : [<a> List<Source<a>>] Source<a>
+def MergeSources = [<a> sources] poll(SourceFan(sources)) {
   fan => fan.case {
     .end! => submit(),
     .spawn(l) r => submit(l, r),

--- a/docs/src/types/box.md
+++ b/docs/src/types/box.md
@@ -102,8 +102,8 @@ module Main
 
 import @core/List
 
-dec Map : <a>[List<a>] <b>[box [a] b] List<b>
-def Map = <a>[list] <b>[f] list.begin.case {
+dec Map : [<a> List<a>, <b> box [a] b] List<b>
+def Map = [<a> list, <b> f] list.begin.case {
   .end! => .end!,
   .item(x) xs => .item(f(x)) xs.loop,
 }
@@ -155,9 +155,9 @@ import {
   @core/List
 }
 
-dec Filter : <a: box>[List<a>] [box [a] Bool] List<a>
+dec Filter : [<a: box> List<a>, box [a] Bool] List<a>
 
-def Filter = <a: box>[list] [predicate] list.begin.case {
+def Filter = [<a: box> list, predicate] list.begin.case {
   .end! => .end!,
   .item(x) xs => predicate(x).case {
     .true! => .item(x) xs.loop,

--- a/docs/src/types/constraints.md
+++ b/docs/src/types/constraints.md
@@ -5,15 +5,15 @@ Generic code often needs to know a little bit about an unknown type.
 For example, this function can return its argument without knowing anything about `a`:
 
 ```par
-dec Identity : <a>[a] a
-def Identity = <a>[x] x
+dec Identity : [<a> a] a
+def Identity = [<a> x] x
 ```
 
 But this one needs to use its value twice:
 
 ```par
-dec Duplicate : <a: box>[a] (a, a)!
-def Duplicate = <a: box>[x] (x, x)!
+dec Duplicate : [<a: box> a] (a, a)!
+def Duplicate = [<a: box> x] (x, x)!
 ```
 
 The `: box` part is a **type constraint**. It says that the unknown type `a` must be non-linear,
@@ -48,7 +48,7 @@ dec ZeroOr : [type a: number, Bool, a] a
 Implicit generic functions use angle-bracket binders:
 
 ```par
-dec Sum : <a: number>[(a) a] a
+dec Sum : [<a: number> (a) a] a
 ```
 
 Existential types can constrain the hidden type:
@@ -60,7 +60,7 @@ type SomeData = (type a: data) a
 Implicit generic pairs can do the same:
 
 ```par
-type DataWithText = <a: data>(a) String
+type DataWithText = (<a: data> a) String
 ```
 
 When you construct a value with a constrained explicit binder, the checked type must satisfy the
@@ -87,8 +87,8 @@ The `box` constraint means values are non-linear. A value whose type is known on
 be copied, reused, or dropped.
 
 ```par
-dec KeepFirst : <a: box>[(a, a)!] a
-def KeepFirst = <a: box>[(first, second)!] first
+dec KeepFirst : [<a: box> (a, a)!] a
+def KeepFirst = [<a: box> (first, second)!] first
 ```
 
 In the example, `second` is not used. That is allowed because `a: box`.
@@ -114,14 +114,14 @@ support:
 - data interpolation in template strings: `#{...}`
 
 ```par
-dec Min : <a: data>[(a) a] a
-def Min = <a: data>[(left) right] if {
+dec Min : [<a: data> (a) a] a
+def Min = [<a: data> (left) right] if {
   left <= right => left,
   else => right,
 }
 
-dec Label : <a: data>[a] String
-def Label = <a: data>[value] `value = #{value}`
+dec Label : [<a: data> a] String
+def Label = [<a: data> value] `value = #{value}`
 ```
 
 The comparison operators use `@core/Data.Compare` under the hood. The `#{...}` template form uses
@@ -160,8 +160,8 @@ module Main
 
 import @core/Number
 
-dec SumPair : <a: number>[(a) a] a
-def SumPair = <a: number>[(left) right] left + right
+dec SumPair : [<a: number> (a) a] a
+def SumPair = [<a: number> (left) right] left + right
 
 dec Zero : [type a: number] a
 def Zero = [type a: number] Number.Zero(type a)
@@ -187,11 +187,11 @@ everything from `number`, plus:
 - `neg`
 
 ```par
-dec Difference : <a: signed>[(a) a] a
-def Difference = <a: signed>[(left) right] left - right
+dec Difference : [<a: signed> (a) a] a
+def Difference = [<a: signed> (left) right] left - right
 
-dec Negate : <a: signed>[a] a
-def Negate = <a: signed>[value] neg value
+dec Negate : [<a: signed> a] a
+def Negate = [<a: signed> value] neg value
 ```
 
 The signed types are:

--- a/docs/src/types/implicit_generics.md
+++ b/docs/src/types/implicit_generics.md
@@ -29,45 +29,52 @@ generics**.
 
 ## Syntax
 
-Implicit generics are not a standalone type. The `<a, ...>` binder is an
-extension of a **[function](./function.md) type**: it must appear immediately
-before the `[...]` of that type.
+Implicit generics are not a standalone type. The `<a, ...>` binder is part of
+one value item inside a **[function](./function.md) type**. It appears immediately
+before the argument type whose value will determine those type variables.
 
 ```par
-<a, b>[Arg] Res
+[<a, b> Arg, Other] Res
 ```
 
-You cannot write `<a>` in front of `either`, `choice`, `box`, or anything else.
+An item may have no binder, one binder, or a binder with several variables. This
+means implicit and ordinary arguments can share one pair of brackets:
+
+```par
+[A, <b> B, C] Res
+```
+
+You cannot use `<a>` outside a function or pair item list, or put it in front of
+`either`, `choice`, `box`, or another complete type.
 
 The key rule is local inference:
 
 **Implicit type variables are inferred only from the single argument
 immediately following the `<...>` binder.**
 
-This is also reflected in the syntax: the bracket right after `<...>` must
-contain exactly one argument type. If you need multiple value arguments, you
-still write a curried function type.
-
-So this is valid:
+The binder does not infer from the other items in the same brackets. For
+example, this function infers `a` from `left` only; `right` is checked afterward
+using the inferred `a`:
 
 ```par
-dec Concat : <a>[List<a>] [List<a>] List<a>
+dec Concat : [<a> List<a>, List<a>] List<a>
 ```
 
-But this is not valid syntax:
+Different items may introduce different variables:
 
 ```par
-dec Concat : <a>[List<a>, List<a>] List<a>
+dec Map : [<a> List<a>, <b> box [a] b] List<b>
 ```
 
-When calling such a function, you can still pass all arguments at once:
+Callers pass the value arguments normally:
 
 ```par
 Concat(left, right)
 ```
 
-The type is still written in curried form, because inference must happen from
-that first argument alone.
+The surface list still represents sequential, nested function types. Attaching
+the binder to an item records exactly which one argument drives each local
+inference step.
 
 One more important point: there is no syntax for “manually specifying” implicit
 type arguments. When designing an API you choose, for each type variable,
@@ -86,15 +93,15 @@ Implicit type parameters can also carry constraints, such as `<a: box>` or
 Start with the `Swap` example, but make it implicit:
 
 ```par
-dec Swap : <a, b>[(a, b)!] (b, a)!
+dec Swap : [<a, b> (a, b)!] (b, a)!
 ```
 
 To construct a value of this type, you also introduce the implicit type names
 at the term level, and then receive the value argument:
 
 ```par
-dec Swap : <a, b>[(a, b)!] (b, a)!
-def Swap = <a, b>[pair]
+dec Swap : [<a, b> (a, b)!] (b, a)!
+def Swap = [<a, b> pair]
   let (first, second)! = pair
   in (second, first)!
 ```
@@ -107,7 +114,7 @@ You can also use implicit generics when the type variable is nested inside a
 larger argument:
 
 ```par
-dec Flatten : <a>[List<List<a>>] List<a>
+dec Flatten : [<a> List<List<a>>] List<a>
 ```
 
 ## Destruction
@@ -149,7 +156,7 @@ A classic example is an anonymous function. The `box` here is not the point —
 it just happens that `Map` takes a boxed function.
 
 ```par
-dec Map : <a>[List<a>] <b>[box [a] b] List<b>
+dec Map : [<a> List<a>, <b> box [a] b] List<b>
 ```
 
 The list argument infers `a`. When checking the mapper, `b` is still unknown,
@@ -181,14 +188,15 @@ There is still no syntax for manually passing an implicit type argument.
 Implicit generics also exist for [pair](./pair.md) types. This is the implicit
 counterpart of [`exists`](./exists.md).
 
-Just like with functions, the `<a, ...>` binder is part of the following pair
-type: it must appear right before the `(...)` of that pair type.
+Just like with functions, the `<a, ...>` binder belongs to one value item, this
+time inside the pair's parentheses. Ordinary and implicit items can be mixed,
+as in `(Header, <a> a) Rest`.
 
 Here is a simple example. `AnyDrop` stores a value of some unknown type, plus a
 small “vtable” for dropping it (a boxed [choice](./choice.md)):
 
 ```par
-type AnyDrop = <a>(a) box choice {
+type AnyDrop = (<a> a) box choice {
   .drop(a) => !,
 }
 ```
@@ -217,7 +225,7 @@ Dually, when you unpack an implicit-generic pair, you introduce a local type
 variable:
 
 ```par
-let <a>(value) vtable = Example
+let (<a> value) vtable = Example
 vtable.drop(value)
 ```
 

--- a/examples/src/Downloader.par
+++ b/examples/src/Downloader.par
@@ -230,8 +230,8 @@ def NewProgressTracker: ProgressTracker = do {
 
 // ---
 
-dec FanIn : <a>[List<List<a>>] List<a>
-def FanIn = <a>[lists] chan yield {
+dec FanIn : [<a> List<List<a>>] List<a>
+def FanIn = [<a> lists] chan yield {
   Cell.Share(yield, lists.begin.case {
     .end! => .end!,
     .item(list) lists => .split(list.begin.case {

--- a/examples/src/MiniGrep.par
+++ b/examples/src/MiniGrep.par
@@ -90,8 +90,8 @@ type Iterator<e, a> = recursive choice {
   }
 }
 
-dec Lines : <e>[String.Parser<e>] Iterator<e, String>
-def Lines = <e>[parser] do { parser.begin } in case {
+dec Lines : [<e> String.Parser<e>] Iterator<e, String>
+def Lines = [<e> parser] do { parser.begin } in case {
   .close => parser.case {
     .empty! => .ok!,
     .ready parser => parser.close,
@@ -115,8 +115,8 @@ def Lines = <e>[parser] do { parser.begin } in case {
   }
 }
 
-dec Filter : <e, a>[Iterator<e, box a>] [box [a] Bool] Iterator<e, a>
-def Filter = <e, a>[iter] [predicate] do { iter.begin } in case {
+dec Filter : [<e, a> Iterator<e, box a>, box [a] Bool] Iterator<e, a>
+def Filter = [<e, a> iter, predicate] do { iter.begin } in case {
   .close => iter.close,
   .next => iter.next.case {
     .end result => .end result,
@@ -133,8 +133,8 @@ def Filter = <e, a>[iter] [predicate] do { iter.begin } in case {
   }
 }
 
-dec Enumerate1 : <e, a>[Iterator<e, a>] Iterator<e, (Nat) a>
-def Enumerate1 = <e, a>[iter] do {
+dec Enumerate1 : [<e, a> Iterator<e, a>] Iterator<e, (Nat) a>
+def Enumerate1 = [<e, a> iter] do {
   let index = 1
   iter.begin
 } in case {

--- a/examples/src/Nondeterminism/SourceFanIn.par
+++ b/examples/src/Nondeterminism/SourceFanIn.par
@@ -29,8 +29,8 @@ type SourceFan<e, a> = recursive either {
   }
 }
 
-dec SourceFanIn : <e, a>[List<Source<e, a>>] Source<(e) List<e>, a>
-def SourceFanIn = <e, a>[sources]
+dec SourceFanIn : [<e, a> List<Source<e, a>>] Source<(e) List<e>, a>
+def SourceFanIn = [<e, a> sources]
   let fan: SourceFan<e, a> = sources.begin.case {
     .end! => .end!,
     .item(source) sources => .split(do { source.begin } in .client case {

--- a/tests/src/NumberData.par
+++ b/tests/src/NumberData.par
@@ -65,7 +65,7 @@ def TestDataGenericFunctions: [Test] ! = [test]
 
 type Format = List<either {
   .str String,
-  .dat<a: data>(a)!,
+  .dat(<a: data> a)!,
 }>
 
 dec RenderFormat : [Format] String
@@ -75,7 +75,7 @@ def RenderFormat = [fmt] do {
     .item(i) => {
       i.case {
         .str s => { builder.add(s) }
-        .dat<a: data>(x)! => { builder.add(x->Data.ToString) }
+        .dat(<a: data> x)! => { builder.add(x->Data.ToString) }
       }
       fmt.loop
     }


### PR DESCRIPTION
Currently, the syntax for implicit generics is like this:
```
dec Map : <a>[List<a>] <b>[box [a] b] List<b>
def Map = <a>[list] <b>[f] ...
```
The generic parameter (such as `a`) is inferred only from the following argument (such as `List<a>`). But written outside of the parentheses like this forces the two arguments to be separated into separate pairs of parentheses.

If we moved the `<a>` inside the parentheses instead, it would still be clear where the generic parameter is inferred from, while using a single pair of parentheses:
```
dec Map : [<a> List<a>, <b> box [a] b] List<b>
def Map = [<a> list, <b> f] ...
```
Notice especially, that the `<a>` and `<b>` still appear in the `def`, but before the argument names.

If we then wrote type annotations inside the `def`, it would look like this:
```
def Map = [<a> list: List<a>, <b> f: box [a] b] ...
```